### PR TITLE
Fetch aks cluster details to json

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,6 +128,120 @@ aks-version-scan:
       ' report/aks_versions.json > report/aks_versions.csv
 
       echo "Report written to report/aks_versions.json and report/aks_versions.csv"
+ 
+      echo "Building AKS inventory with node pools and VMSS image versions"
+      jq -c '.[]' report/aks_clusters_basic.json | while read -r cluster; do
+        NAME=$(echo "$cluster" | jq -r .name)
+        RG=$(echo "$cluster" | jq -r .resourceGroup)
+ 
+        CLUSTER_SHOW=$(az aks show -g "$RG" -n "$NAME" -o json)
+        NODE_RG=$(echo "$CLUSTER_SHOW" | jq -r .nodeResourceGroup)
+ 
+        UPG=$(az aks get-upgrades -g "$RG" -n "$NAME" -o json)
+        CURR=$(echo "$cluster" | jq -r .currentVersion)
+        CURR_FROM_UPG=$(echo "$UPG" | jq -r '.controlPlaneProfile.kubernetesVersion')
+        CURRENT_VERSION=${CURR:-$CURR_FROM_UPG}
+        if [ -z "$CURRENT_VERSION" ] || [ "$CURRENT_VERSION" = "null" ]; then
+          CURRENT_VERSION=""
+        fi
+        if [ -n "$CURRENT_VERSION" ]; then
+          MAJOR_MINOR=$(echo "$CURRENT_VERSION" | awk -F. '{print $1 "." $2}')
+        else
+          MAJOR_MINOR=""
+        fi
+        LATEST_SAME_MINOR=$(echo "$UPG" | jq -r --arg mm "$MAJOR_MINOR" '
+          [
+            .controlPlaneProfile.upgrades[]?.kubernetesVersion
+            | select($mm != "" and startswith($mm + "."))
+          ] | (if $mm == "" then [] else . end)
+            | map(.) + [ .controlPlaneProfile.kubernetesVersion ]
+            | unique | sort | last // ""
+        ')
+        NEXT_MINOR_CANDIDATES_JSON=$(echo "$UPG" | jq -c --arg mm "$MAJOR_MINOR" '
+          (
+            if $mm == "" then [] else
+            [
+              .controlPlaneProfile.upgrades[]?.kubernetesVersion
+              | select((. | startswith($mm + ".")) | not)
+            ]
+            end
+          ) | unique | sort
+        ')
+        NEW_MINOR_AVAILABLE=$(echo "$NEXT_MINOR_CANDIDATES_JSON" | jq 'length > 0')
+        NEW_MINOR_AVAILABLE=$(echo "$NEW_MINOR_AVAILABLE" | tr -d '\n\r')
+ 
+        NODEPOOLS=$(az aks nodepool list -g "$RG" --cluster-name "$NAME" -o json | jq '[.[] | {
+          name: .name,
+          mode: .mode,
+          count: .count,
+          vmSize: .vmSize,
+          osType: .osType,
+          osSKU: (.osSKU // ""),
+          osDiskType: .osDiskType,
+          osDiskSizeGB: .osDiskSizeGB,
+          enableAutoScaling: .enableAutoScaling,
+          minCount: (.minCount // 0),
+          maxCount: (.maxCount // 0),
+          nodeLabels: (.nodeLabels // {}),
+          nodeTaints: (.nodeTaints // []),
+          maxPods: (.maxPods // 0),
+          orchestratorVersion: .orchestratorVersion,
+          nodeImageVersion: (.nodeImageVersion // ""),
+          upgradeSettings: (.upgradeSettings // {}),
+          availabilityZones: (.availabilityZones // []),
+          scaleSetPriority: (.scaleSetPriority // ""),
+          scaleSetEvictionPolicy: (.scaleSetEvictionPolicy // "")
+        }]')
+ 
+        VMSS_JSON="[]"
+        if [ -n "$NODE_RG" ] && [ "$NODE_RG" != "null" ]; then
+          VMSS_JSON=$(az vmss list -g "$NODE_RG" -o json | jq '[.[] | {
+            name: .name,
+            skuName: (.sku.name // ""),
+            capacity: (.sku.capacity // 0),
+            upgradePolicyMode: (.upgradePolicy.mode // ""),
+            tags: (.tags // {}),
+            imageReference: (.virtualMachineProfile.storageProfile.imageReference // {})
+          }]')
+        fi
+ 
+        jq -n \
+          --argjson basic "$cluster" \
+          --argjson clusterShow "$CLUSTER_SHOW" \
+          --arg currentVersion "$CURRENT_VERSION" \
+          --arg latestPatchSameMinor "$LATEST_SAME_MINOR" \
+          --argjson nextMinorCandidates "$NEXT_MINOR_CANDIDATES_JSON" \
+          --argjson newMinorAvailable "$NEW_MINOR_AVAILABLE" \
+          --argjson nodepools "$NODEPOOLS" \
+          --argjson vmss "$VMSS_JSON" '
+          {
+            name: $basic.name,
+            resourceGroup: $basic.resourceGroup,
+            location: $basic.location,
+            cluster: {
+              id: ($clusterShow.id // null),
+              kubernetesVersion: ($clusterShow.kubernetesVersion // null),
+              dnsPrefix: ($clusterShow.dnsPrefix // null),
+              nodeResourceGroup: ($clusterShow.nodeResourceGroup // null),
+              privateCluster: ($clusterShow.apiServerAccessProfile.enablePrivateCluster // null),
+              sku: ($clusterShow.sku // null),
+              networkProfile: ($clusterShow.networkProfile // null),
+              autoUpgradeProfile: ($clusterShow.autoUpgradeProfile // null),
+              powerState: ($clusterShow.powerState // null)
+            },
+            versionPattern: {
+              currentVersion: $currentVersion,
+              latestPatchSameMinor: $latestPatchSameMinor,
+              newMinorAvailable: $newMinorAvailable,
+              nextMinorVersions: $nextMinorCandidates
+            },
+            nodePools: $nodepools,
+            vmScaleSets: $vmss
+          }
+        '
+      done | jq -s '.' > report/aks_inventory.json
+ 
+      echo "Inventory written to report/aks_inventory.json"
   artifacts:
     when: always
     paths:


### PR DESCRIPTION
Add a new `aks_inventory.json` artifact to the GitLab CI pipeline to provide comprehensive AKS cluster details, including version patterns, node pool specifics, and VMSS image versions.

---
<a href="https://cursor.com/background-agent?bcId=bc-29e47a69-b8cc-4da7-8e3a-c24f78be2ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29e47a69-b8cc-4da7-8e3a-c24f78be2ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

